### PR TITLE
Various fixes

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -242,8 +242,14 @@ Blockchain.prototype.queueCall = function(tx_params, callback) {
 };
 
 Blockchain.prototype.queueAction = function(method, tx_params, callback) {
-  if (tx_params.from == null)
-    tx_params.from = this.coinbase;
+  if (tx_params.from == null) {
+    if (method === 'eth_call')
+      tx_params.from = this.coinbase;
+    else {
+      callback(new Error("from not found; is required"));
+      return;
+    }
+  }
 
   tx_params.from = this.toHex(tx_params.from);
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -242,10 +242,8 @@ Blockchain.prototype.queueCall = function(tx_params, callback) {
 };
 
 Blockchain.prototype.queueAction = function(method, tx_params, callback) {
-  if (tx_params.from == null) {
-    callback(new Error("from not found; is required"));
-    return;
-  }
+  if (tx_params.from == null)
+    tx_params.from = this.coinbase;
 
   tx_params.from = this.toHex(tx_params.from);
 

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -82,22 +82,26 @@ Blockchain.prototype.accountAddresses = function() {
 
 Blockchain.prototype.createBlock = function() {
   var block = new Block();
+  var parent = this.blocks.length != 0 ? this.blocks[this.blocks.length - 1] : null;
+
   block.header.gasLimit = '0x2fefd8';
+
+  // Ensure we have the right block number for the VM.
+  block.header.number = this.toHex(this.blockNumber + 1);
+
+  // Set the timestamp before processing txs
+  block.header.timestamp = this.toHex(new Date().getTime() / 1000 | 0);
+
+  if (parent != null) {
+    block.header.parentHash = this.toHex(parent.hash());
+  }
+
   return block;
 }
 
 Blockchain.prototype.mine = function() {
   this.blockNumber += 1;
   var block = this.pendingBlock;
-  var parent = this.blocks.length != 0 ? this.blocks[this.blocks.length - 1] : null;
-
-  // Update the header for when the block was mined.
-  block.header.timestamp = this.toHex(new Date().getTime());
-  block.header.number = this.toHex(this.blockNumber);
-
-  if (parent != null) {
-    block.header.parentHash = this.toHex(parent.hash());
-  }
 
   this.blocks.push(block);
 
@@ -344,9 +348,6 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
 
     // Add the transaction to the block.
     block.transactions.push(tx);
-
-    // Ensure we have the right block number for the VM.
-    block.header.number = self.blockNumber + 1;
 
     self.vm.runBlock({
       block: block,

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -90,13 +90,17 @@ Blockchain.prototype.createBlock = function() {
   block.header.number = this.toHex(this.blockNumber + 1);
 
   // Set the timestamp before processing txs
-  block.header.timestamp = this.toHex(new Date().getTime() / 1000 | 0);
+  block.header.timestamp = this.toHex(this.currentTime());
 
   if (parent != null) {
     block.header.parentHash = this.toHex(parent.hash());
   }
 
   return block;
+}
+
+Blockchain.prototype.currentTime = function() {
+  return new Date().getTime() / 1000 | 0;
 }
 
 Blockchain.prototype.mine = function() {
@@ -322,6 +326,9 @@ Blockchain.prototype.processNextAction = function(override) {
     }
   };
 
+  // Update the latest unmined block's timestamp before calls or txs
+  this.updateCurrentTime();
+
   if (queued.method == "eth_sendTransaction") {
     this.processTransaction(queued.from, queued.rawTx, intermediary);
   } else {
@@ -480,5 +487,10 @@ Blockchain.prototype.processCall = function(from, rawTx, callback) {
     });
   });
 };
+
+Blockchain.prototype.updateCurrentTime = function() {
+  var block = this.latestBlock();
+  block.header.timestamp = this.toHex(this.currentTime());
+}
 
 module.exports = Blockchain;

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -325,13 +325,15 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
   var self = this;
 
   var block = this.pendingBlock;
-  var account = new Buffer(utils.stripHexPrefix(from), "hex");
+  var address = new Buffer(utils.stripHexPrefix(from), "hex");
   var privateKey = new Buffer(this.accounts[from].secretKey, 'hex');
 
-  this.vm.stateManager.getAccount(account, function(err, result) {
+  this.stateTrie.get(address, function(err, val) {
+    var account = new Account(val);
+
     // If the user specified a nonce, use that instead.
     if (rawTx.nonce == null) {
-      rawTx.nonce = self.toHex(result.nonce);
+      rawTx.nonce = self.toHex(account.nonce);
     }
 
     var tx = new Transaction(rawTx);
@@ -409,9 +411,15 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
 
       self.transactions[tx_hash] = tx_result;
 
+      console.log("");
+
       if (tx_result.createdAddress != null) {
+        console.log("  Contract created: " + tx_result.createdAddress);
         self.contracts[tx_result.createdAddress] = rawTx.data;
       }
+
+      console.log("  Gas usage: " + utils.bufferToInt(self.toHex(tx_result.gasUsed)));
+      console.log("");
 
       self.mine();
 
@@ -424,13 +432,15 @@ Blockchain.prototype.processCall = function(from, rawTx, callback) {
   var self = this;
 
   var block = this.latestBlock();
-  var account = new Buffer(utils.stripHexPrefix(from), "hex");
+  var address = new Buffer(utils.stripHexPrefix(from), "hex");
   var privateKey = new Buffer(this.accounts[from].secretKey, 'hex');
 
-  this.vm.stateManager.getAccount(account, function(err, result) {
+  this.stateTrie.get(address, function(err, val) {
+    var account = new Account(val);
+
     // If the user specified a nonce, use that instead.
     if (rawTx.nonce == null) {
-      rawTx.nonce = self.toHex(result.nonce);
+      rawTx.nonce = self.toHex(account.nonce);
     }
 
     var tx = new Transaction(rawTx);
@@ -456,7 +466,12 @@ Blockchain.prototype.processCall = function(from, rawTx, callback) {
         return;
       }
 
-      callback(null, self.toHex(results.vm.return));
+      if (results.vm.exception != 1) {
+        callback(new Error("VM Exception while executing transaction: " + results.vm.exceptionError));
+        return;
+      }
+
+      callback(null, self.toHex(results.vm.return || "0x0"));
     });
   });
 };

--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -363,6 +363,11 @@ Blockchain.prototype.processTransaction = function(from, rawTx, callback) {
       var receipt = results.receipts[0];
       var result = results.results[0];
 
+      if (result.vm.exception != 1) {
+        callback(new Error("VM Exception while executing transaction: " + result.vm.exceptionError));
+        return;
+      }
+
       var logs = [];
 
       for (var i = 0; i < receipt.logs.length; i++) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,6 +81,8 @@ Server = {
       functions[method] = createHandler(method);
     });
 
+    // TODO: the reviver option is a hack to allow batches to work with jayson
+    // it become unecessary after the fix of this bug https://github.com/ethereum/web3.js/issues/345
     var server = jayson.server(functions, {
       reviver: function(key, val) {
         if (typeof val === 'object' && val.hasOwnProperty('method') &&

--- a/lib/server.js
+++ b/lib/server.js
@@ -102,7 +102,7 @@ Server = {
       proxyRes.headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept';
     });
 
-    proxy.on('error', (error, req, res) => {
+    proxy.on('error', function(error, req, res) {
       console.log(error);
     });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -82,7 +82,8 @@ Server = {
     });
 
     var server = jayson.server(functions);
-    server.http().listen(servicePort);
+    var http = server.http();
+    http.listen(servicePort);
 
     var proxy = httpProxy.createProxyServer({target:'http://localhost:' + servicePort}).listen(port);
 
@@ -99,6 +100,10 @@ Server = {
       proxyRes.headers['Access-Control-Allow-Origin'] = '*';
       proxyRes.headers['Access-Control-Allow-Methods'] = '*';
       proxyRes.headers['Access-Control-Allow-Headers'] = 'Origin, X-Requested-With, Content-Type, Accept';
+    });
+
+    proxy.on('error', (error, req, res) => {
+      console.log(error);
     });
 
     console.log("EtherSim v" + pkg.version);

--- a/lib/server.js
+++ b/lib/server.js
@@ -81,7 +81,15 @@ Server = {
       functions[method] = createHandler(method);
     });
 
-    var server = jayson.server(functions);
+    var server = jayson.server(functions, {
+      reviver: function(key, val) {
+        if (typeof val === 'object' && val.hasOwnProperty('method') &&
+            val.method === 'eth_call' && val.hasOwnProperty('params') &&
+            val.params.constructor === Array && val.params.length === 1)
+          val.params.push('latest');
+        return val;
+      }
+    });
     var http = server.http();
     http.listen(servicePort);
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "body-parser": "^1.13.2",
     "request": "^2.60.0",
     "http-proxy": "^1.12.0",
-    "ethereumjs-vm": "ethereum/ethereumjs-vm#master",
+    "ethereumjs-vm": "^1.0.2",
     "ethereumjs-tx": "^0.6.9",
     "ethereumjs-block": "^1.0.2",
     "ethereumjs-account": "^1.0.4",


### PR DESCRIPTION
This PR includes various fixes from both me and @ckeenan. They include:
1. Outputting the gas costs in the log when a contract is created
2. Returning errors when there are vm exceptions, so you know exactly which transaction or call caused the issue
3. Fixing a bug where `block.timestamp` should have been in seconds vs milliseconds (@ckeenan)
4. Setting block headers in createBlock(), otherwise block.timestamp isn't available to ethereumjs-vm (@ckeenan)
5. Set `tx_params.from` to `this.coinbase` if null for `eth_call`'s (@ckeenan)
6. Inject defaultBlock `"latest"` into eth_call params if it's not already there. This was missing during batched eth_calls (and needed to be fixed at the jayson level). Now batches work as expected. (@ckeenan)

See https://github.com/tcoulter/EtherSim/pull/1 for discussion of @ckeenan's work.
