### PR TITLE
Fix typo `ethUtil` to `utils`

### DIFF
--- a/lib/blockchain.js
+++ b/lib/blockchain.js
@@ -133,7 +133,7 @@ Blockchain.prototype.createBlock = function() {
 
 Blockchain.prototype.setGasLimit = function(newLimit) {
   if (typeof(newLimit) == "number") {
-    newLimit = ethUtil.intToHex(newLimit);
+    newLimit = utils.intToHex(newLimit);
   }
   this.gasLimit = newLimit;
   this.pendingBlock.header.gasLimit = newLimit;


### PR DESCRIPTION
Seems like a typo; changed locally and everything works for me, so presumably a fix. Please check.
